### PR TITLE
Add Domain-driven Design Dortmund

### DIFF
--- a/app/src/content/communities.yaml
+++ b/app/src/content/communities.yaml
@@ -71,6 +71,12 @@ communities:
     city: "Cologne"
     url: "https://www.meetup.com/Domain-Driven-Design-Koln-Bonn/"
     img: "https://secure.meetupstatic.com/photos/event/d/2/4/b/600_463013835.jpeg"
+  - name: "Do DDD - Domain Driven Design Dortmund"
+    id: 21
+    country: "Germany"
+    city: "Dortmund"
+    url: "https://www.meetup.com/de-DE/ddd-dortmund/"
+    img: "https://secure.meetupstatic.com/photos/event/a/e/d/7/clean_518564759.webp" 
   - name: "Domain-Driven Design Injection Kharkiv"
     id: 12
     country: "Ukraine"


### PR DESCRIPTION
This adds the new Do DDD (Domain-driven Design Dortmund) community.

Note: While the "id" is higher then the rest, I intentionally added it at the end of the "Germany" communites instead of at the end of the file. This visually keeps all German communities in a group, otherwise it would seem a bit _chaotic_.

I ran `yarn run develop` to test the changes, as well as running the tests. However I skipped commiting the changes from formatting and linting other files, as there were too many unrelated changes.